### PR TITLE
add AirDrop support

### DIFF
--- a/Audiobook Player/AppDelegate.swift
+++ b/Audiobook Player/AppDelegate.swift
@@ -30,6 +30,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         UserDefaults.standard.set(nil, forKey: "sleep_timer")
         return true
     }
+    
+    func application(_ app: UIApplication,
+                              open url: URL,
+                              options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        // This function is called when the app is opened with a audio file url,
+        // like when receiving files through AirDrop
+        
+        let fmanager = FileManager.default
+
+        let filename = url.lastPathComponent
+        let documentsURL = fmanager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let destinationURL = documentsURL.appendingPathComponent(filename)
+        
+        // move file from Inbox to Document folder
+        do {
+            try fmanager.moveItem(at: url, to: destinationURL)
+        } catch {
+            // TODO: How should this case be handled?
+            try! fmanager.removeItem(at: url)
+            return false
+        }
+        return true
+    }
 
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.

--- a/Audiobook Player/Info.plist
+++ b/Audiobook Player/Info.plist
@@ -4,6 +4,21 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Audiobook</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.audio</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This commit allows the app to receive and handle audio files sent through AirDrop and other file-sharing means.

* make this app a file handler for various audio file-types in Info.plist
* add a function to handle incoming files in AppDelegate.swift
    * this function simply moves the file from Documents/Inbox/ to Documents/
* ignore the Inbox/ directory when loading audiobooks in ListBooksViewController.swift
    * (the Inbox/ folder is created for incoming files by the OS)
* add the filename as a fallback option for the audiobook title if the metadata can't be parsed properly