### PR TITLE
Improvement: PlayerView UI Shows Cover Art

### DIFF
--- a/Audiobook Player/Base.lproj/Main.storyboard
+++ b/Audiobook Player/Base.lproj/Main.storyboard
@@ -366,7 +366,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Smarter Faster Better" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="2KB-bk-jYi">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Smarter Faster Better" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="2KB-bk-jYi">
                                 <rect key="frame" x="20" y="56" width="290" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="33" id="p4B-f2-nEp"/>

--- a/Audiobook Player/Base.lproj/Main.storyboard
+++ b/Audiobook Player/Base.lproj/Main.storyboard
@@ -366,28 +366,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GcK-bx-Lp0">
-                                <rect key="frame" x="262.5" y="320.5" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="25" id="RyI-F6-RVP"/>
-                                    <constraint firstAttribute="width" constant="25" id="yVi-8t-2r7"/>
-                                </constraints>
-                                <state key="normal" image="forwardButton"/>
-                                <connections>
-                                    <action selector="forwardPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="qpI-u0-QuJ"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xm9-P8-cWQ">
-                                <rect key="frame" x="87.5" y="320.5" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="25" id="JRv-Ky-te4"/>
-                                    <constraint firstAttribute="width" constant="25" id="ni5-vM-DsI"/>
-                                </constraints>
-                                <state key="normal" image="rewindButton"/>
-                                <connections>
-                                    <action selector="rewindPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="BDV-5d-B7K"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Smarter Faster Better" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="2KB-bk-jYi">
                                 <rect key="frame" x="20" y="56" width="290" height="33"/>
                                 <constraints>
@@ -407,19 +385,19 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CQn-JB-tMb">
-                                <rect key="frame" x="206" y="421.5" width="46" height="21"/>
+                                <rect key="frame" x="206" y="520" width="46" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.57647058823529407" green="0.55294117647058827" blue="0.5725490196078431" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pIa-Ca-Qef">
-                                <rect key="frame" x="122.5" y="421.5" width="46" height="21"/>
+                                <rect key="frame" x="122" y="520" width="46" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="|" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mgG-dL-P0p">
-                                <rect key="frame" x="183.5" y="417.5" width="7.5" height="25.5"/>
+                                <rect key="frame" x="183" y="515" width="8" height="26"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                 <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -431,38 +409,15 @@
                                     <constraint firstAttribute="height" constant="8" id="n2F-Fp-Won"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+30s" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMK-z6-AR3">
-                                <rect key="frame" x="254.5" y="354.5" width="40" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-30s" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KeM-wX-aYz">
-                                <rect key="frame" x="81.5" y="354.5" width="37" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Ah-kW-bx4">
-                                <rect key="frame" x="18" y="452.5" width="339" height="31"/>
+                                <rect key="frame" x="17" y="551" width="339" height="31"/>
                             </slider>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MUH-Ds-5l0">
-                                <rect key="frame" x="175.5" y="496.5" width="24" height="21"/>
+                                <rect key="frame" x="175" y="595" width="24" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EV6-kJ-RSt">
-                                <rect key="frame" x="153.5" y="299.5" width="68" height="68"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="68" id="Ced-al-LA9"/>
-                                    <constraint firstAttribute="height" constant="68" id="EcU-UU-wnU"/>
-                                </constraints>
-                                <state key="normal" image="playButton"/>
-                                <connections>
-                                    <action selector="playPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="VAA-fY-HFo"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qml-C5-mHf">
                                 <rect key="frame" x="20" y="636" width="75" height="30"/>
                                 <state key="normal" title="Speed 1.0x">
@@ -484,7 +439,7 @@
                                     <action selector="presentChapter:" destination="JEX-9P-axG" eventType="touchUpInside" id="RbM-Sn-Qt2"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JHJ-U2-q0F" userLabel="More Button">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JHJ-U2-q0F" userLabel="More Button">
                                 <rect key="frame" x="326" y="35" width="44" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="44" id="KG0-2T-a0j"/>
@@ -496,7 +451,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o5L-ES-pPP" userLabel="Sleep Button">
-                                <rect key="frame" x="172.5" y="632" width="30" height="30"/>
+                                <rect key="frame" x="172" y="632" width="30" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="30" id="EO0-QS-h2A"/>
                                     <constraint firstAttribute="width" secondItem="o5L-ES-pPP" secondAttribute="height" multiplier="1:1" id="rwd-vj-e34"/>
@@ -506,15 +461,66 @@
                                     <action selector="didPressSleepTimer:" destination="JEX-9P-axG" eventType="touchUpInside" id="oRE-0j-Yh9"/>
                                 </connections>
                             </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Wrj-aG-VQg">
+                                <rect key="frame" x="0.0" y="116" width="375" height="267"/>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GcK-bx-Lp0">
+                                <rect key="frame" x="262" y="432" width="25" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="25" id="RyI-F6-RVP"/>
+                                    <constraint firstAttribute="width" constant="25" id="yVi-8t-2r7"/>
+                                </constraints>
+                                <state key="normal" image="forwardButton"/>
+                                <connections>
+                                    <action selector="forwardPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="qpI-u0-QuJ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xm9-P8-cWQ">
+                                <rect key="frame" x="87" y="432" width="25" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="25" id="JRv-Ky-te4"/>
+                                    <constraint firstAttribute="width" constant="25" id="ni5-vM-DsI"/>
+                                </constraints>
+                                <state key="normal" image="rewindButton"/>
+                                <connections>
+                                    <action selector="rewindPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="BDV-5d-B7K"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+30s" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMK-z6-AR3">
+                                <rect key="frame" x="254" y="466" width="40" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-30s" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KeM-wX-aYz">
+                                <rect key="frame" x="81" y="466" width="37" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EV6-kJ-RSt">
+                                <rect key="frame" x="153" y="411" width="68" height="68"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="68" id="Ced-al-LA9"/>
+                                    <constraint firstAttribute="height" constant="68" id="EcU-UU-wnU"/>
+                                </constraints>
+                                <state key="normal" image="playButton"/>
+                                <connections>
+                                    <action selector="playPressed:" destination="JEX-9P-axG" eventType="touchUpInside" id="VAA-fY-HFo"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.078431372549019607" green="0.082352941176470587" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="KeM-wX-aYz" firstAttribute="centerX" secondItem="Xm9-P8-cWQ" secondAttribute="centerX" id="0xJ-t9-sZr"/>
-                            <constraint firstAttribute="trailing" secondItem="3Ah-kW-bx4" secondAttribute="trailing" constant="20" id="21e-Ur-6j3"/>
+                            <constraint firstAttribute="trailing" secondItem="3Ah-kW-bx4" secondAttribute="trailing" constant="21" id="21e-Ur-6j3"/>
+                            <constraint firstItem="Wrj-aG-VQg" firstAttribute="top" secondItem="2KB-bk-jYi" secondAttribute="bottom" constant="27" id="2Ht-qc-y2U"/>
                             <constraint firstItem="o5L-ES-pPP" firstAttribute="centerX" secondItem="MUH-Ds-5l0" secondAttribute="centerX" id="32u-7N-8Zc"/>
                             <constraint firstItem="Tzw-qS-O7I" firstAttribute="leading" secondItem="svH-Pt-448" secondAttribute="leading" id="3hN-nS-1ke"/>
                             <constraint firstItem="Ugu-r8-8OF" firstAttribute="leading" secondItem="svH-Pt-448" secondAttribute="leading" constant="20" id="3j2-3N-H65"/>
                             <constraint firstItem="EV6-kJ-RSt" firstAttribute="centerX" secondItem="svH-Pt-448" secondAttribute="centerX" id="3zD-g7-rQL"/>
+                            <constraint firstItem="EV6-kJ-RSt" firstAttribute="top" secondItem="Wrj-aG-VQg" secondAttribute="bottom" constant="28" id="5h1-ea-Ht7"/>
+                            <constraint firstItem="Wrj-aG-VQg" firstAttribute="leading" secondItem="Tzw-qS-O7I" secondAttribute="leading" id="6kZ-Zg-b7J"/>
                             <constraint firstItem="Tzw-qS-O7I" firstAttribute="top" secondItem="SYR-Wa-9uf" secondAttribute="bottom" id="6zu-Gs-Ere"/>
                             <constraint firstItem="mgG-dL-P0p" firstAttribute="leading" secondItem="pIa-Ca-Qef" secondAttribute="trailing" constant="15" id="9OE-EV-CQM"/>
                             <constraint firstItem="Xm9-P8-cWQ" firstAttribute="centerY" secondItem="EV6-kJ-RSt" secondAttribute="centerY" id="BYj-sA-jgw"/>
@@ -537,21 +543,22 @@
                             <constraint firstItem="GAO-Cl-Wes" firstAttribute="top" secondItem="I6W-6G-1Lz" secondAttribute="bottom" constant="1" id="fj1-xT-fdE"/>
                             <constraint firstItem="JHJ-U2-q0F" firstAttribute="top" secondItem="Ugu-r8-8OF" secondAttribute="top" id="h88-mB-C6X"/>
                             <constraint firstAttribute="trailing" secondItem="2KB-bk-jYi" secondAttribute="trailing" constant="80" id="hFL-RB-ejd"/>
+                            <constraint firstItem="Wrj-aG-VQg" firstAttribute="trailing" secondItem="Tzw-qS-O7I" secondAttribute="trailing" id="hHF-8n-sdH"/>
                             <constraint firstItem="mgG-dL-P0p" firstAttribute="centerX" secondItem="EV6-kJ-RSt" secondAttribute="centerX" id="jZQ-nX-v2R"/>
                             <constraint firstItem="2KB-bk-jYi" firstAttribute="top" secondItem="Ugu-r8-8OF" secondAttribute="bottom" id="k1p-PG-ju4"/>
-                            <constraint firstItem="I6W-6G-1Lz" firstAttribute="trailing" secondItem="3Ah-kW-bx4" secondAttribute="trailing" id="kWc-AX-rZ5"/>
+                            <constraint firstItem="I6W-6G-1Lz" firstAttribute="trailing" secondItem="3Ah-kW-bx4" secondAttribute="trailing" constant="1" id="kWc-AX-rZ5"/>
                             <constraint firstItem="JHJ-U2-q0F" firstAttribute="bottom" secondItem="2KB-bk-jYi" secondAttribute="bottom" id="luu-Tp-trT"/>
-                            <constraint firstItem="EV6-kJ-RSt" firstAttribute="centerY" secondItem="svH-Pt-448" secondAttribute="centerY" id="lys-iz-0XG"/>
+                            <constraint firstItem="EV6-kJ-RSt" firstAttribute="centerY" secondItem="svH-Pt-448" secondAttribute="centerY" constant="111.5" id="lys-iz-0XG"/>
                             <constraint firstItem="LMK-z6-AR3" firstAttribute="top" secondItem="GcK-bx-Lp0" secondAttribute="bottom" constant="9" id="oht-0d-Jo7"/>
                             <constraint firstItem="3Ah-kW-bx4" firstAttribute="top" secondItem="mgG-dL-P0p" secondAttribute="bottom" constant="10" id="qkm-kJ-Okn"/>
                             <constraint firstAttribute="trailing" secondItem="JHJ-U2-q0F" secondAttribute="trailing" constant="5" id="sOe-tj-Lik"/>
-                            <constraint firstItem="mgG-dL-P0p" firstAttribute="top" secondItem="EV6-kJ-RSt" secondAttribute="bottom" constant="50" id="szd-qC-Slu"/>
+                            <constraint firstItem="mgG-dL-P0p" firstAttribute="top" secondItem="EV6-kJ-RSt" secondAttribute="bottom" constant="36" id="szd-qC-Slu"/>
                             <constraint firstItem="CQn-JB-tMb" firstAttribute="leading" secondItem="mgG-dL-P0p" secondAttribute="trailing" constant="15" id="u9S-nP-Ze4"/>
-                            <constraint firstItem="qml-C5-mHf" firstAttribute="leading" secondItem="3Ah-kW-bx4" secondAttribute="leading" id="v8T-N8-cAv"/>
+                            <constraint firstItem="qml-C5-mHf" firstAttribute="leading" secondItem="3Ah-kW-bx4" secondAttribute="leading" constant="1" id="v8T-N8-cAv"/>
                             <constraint firstItem="JHJ-U2-q0F" firstAttribute="trailing" secondItem="3Ah-kW-bx4" secondAttribute="trailing" id="v8p-TR-zzd"/>
                             <constraint firstItem="GAO-Cl-Wes" firstAttribute="top" secondItem="qml-C5-mHf" secondAttribute="bottom" constant="1" id="vuk-Y5-uzV"/>
                             <constraint firstItem="MUH-Ds-5l0" firstAttribute="top" secondItem="3Ah-kW-bx4" secondAttribute="bottom" constant="13.5" id="xAF-HV-uFp"/>
-                            <constraint firstItem="3Ah-kW-bx4" firstAttribute="leading" secondItem="svH-Pt-448" secondAttribute="leadingMargin" constant="4" id="xwi-9C-5dz"/>
+                            <constraint firstItem="3Ah-kW-bx4" firstAttribute="leading" secondItem="svH-Pt-448" secondAttribute="leadingMargin" constant="3" id="xwi-9C-5dz"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -567,10 +574,12 @@
                     <connections>
                         <outlet property="authorLabel" destination="Ugu-r8-8OF" id="hKh-QA-8iJ"/>
                         <outlet property="chaptersButton" destination="I6W-6G-1Lz" id="w77-CO-MMc"/>
+                        <outlet property="coverImageView" destination="Wrj-aG-VQg" id="pFy-Kq-uE9"/>
                         <outlet property="currentTimeLabel" destination="pIa-Ca-Qef" id="SKl-dd-Pzj"/>
                         <outlet property="forwardButton" destination="GcK-bx-Lp0" id="d0D-Yu-eiw"/>
                         <outlet property="leftVerticalView" destination="Tzw-qS-O7I" id="85b-PT-4hP"/>
                         <outlet property="maxTimeLabel" destination="CQn-JB-tMb" id="7pQ-ZU-iCW"/>
+                        <outlet property="optionsIndicatorButton" destination="JHJ-U2-q0F" id="tsh-fg-nkP"/>
                         <outlet property="percentageLabel" destination="MUH-Ds-5l0" id="GC6-B3-P4x"/>
                         <outlet property="playButton" destination="EV6-kJ-RSt" id="wNC-Tz-V7U"/>
                         <outlet property="rewindButton" destination="Xm9-P8-cWQ" id="Jz4-vo-3zS"/>
@@ -587,7 +596,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FJe-Yq-33r" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1534" y="-558"/>
+            <point key="canvasLocation" x="1533.5999999999999" y="-558.17091454272872"/>
         </scene>
         <!--Settings-->
         <scene sceneID="GOZ-93-E2V">

--- a/Audiobook Player/PlayerViewController.swift
+++ b/Audiobook Player/PlayerViewController.swift
@@ -16,6 +16,7 @@ import StoreKit
 class PlayerViewController: UIViewController {
     @IBOutlet weak var authorLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var optionsIndicatorButton: UIButton!
     
     @IBOutlet weak var playButton: UIButton!
     @IBOutlet weak var forwardButton: UIButton!
@@ -35,6 +36,8 @@ class PlayerViewController: UIViewController {
     @IBOutlet weak var speedButton: UIButton!
     @IBOutlet weak var sleepButton: UIButton!
     
+    @IBOutlet weak var coverImageView: UIImageView!
+    
     @IBOutlet weak var sleepTimerWidthConstraint: NSLayoutConstraint!
     
     //keep in memory images to toggle play/pause
@@ -50,19 +53,28 @@ class PlayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let averageArtworkColor = UIColor(averageColorFrom: currentBook.artwork) ?? UIColor.flatSkyBlueColorDark()
+        
         //set UI colors
-        let colors:[UIColor] = [
-            UIColor.flatGrayColorDark(),
-            UIColor.flatSkyBlueColorDark()
+        let artworkColors:[UIColor] = [
+            averageArtworkColor!,
+            UIColor.flatBlack()
         ]
-        self.view.backgroundColor = GradientColor(.radial, frame: view.frame, colors: colors)
-        self.leftVerticalView.backgroundColor = UIColor.flatRed()
+        self.view.backgroundColor = GradientColor(.topToBottom, frame: view.frame, colors: artworkColors)
+        
+        self.leftVerticalView.backgroundColor = averageArtworkColor
         self.maxTimeLabel.textColor = UIColor.flatWhiteColorDark()
-        self.authorLabel.textColor = UIColor.flatWhiteColorDark()
+        
+        self.titleLabel.textColor = UIColor(contrastingBlackOrWhiteColorOn:averageArtworkColor!, isFlat:true)
+        self.authorLabel.textColor = UIColor(contrastingBlackOrWhiteColorOn:averageArtworkColor!, isFlat:true)
+        self.optionsIndicatorButton.tintColor = UIColor(contrastingBlackOrWhiteColorOn:averageArtworkColor!, isFlat:true)
+        
         self.timeSeparator.textColor = UIColor.flatWhiteColorDark()
         self.chaptersButton.setTitleColor(UIColor.flatGray(), for: .disabled)
         self.speedButton.setTitleColor(UIColor.flatGray(), for: .disabled)
         self.sleepButton.tintColor = UIColor.white
+        
+        self.coverImageView.image = currentBook.artwork
         
         modalPresentationCapturesStatusBarAppearance = true
         

--- a/Audiobook Player/PlayerViewController.swift
+++ b/Audiobook Player/PlayerViewController.swift
@@ -76,6 +76,13 @@ class PlayerViewController: UIViewController {
         
         self.coverImageView.image = currentBook.artwork
         
+        //Drop shadow on cover view
+        coverImageView.layer.shadowColor = UIColor.flatBlack().cgColor
+        coverImageView.layer.shadowOffset = CGSize(width: 0, height: 4)
+        coverImageView.layer.shadowOpacity = 0.6
+        coverImageView.layer.shadowRadius = 6.0
+        coverImageView.clipsToBounds = false
+        
         modalPresentationCapturesStatusBarAppearance = true
         
         self.setStatusBarStyle(UIStatusBarStyleContrast)


### PR DESCRIPTION
Modified the player view to show the cover art of whatever book is being listened to, centered above the play controls. 

In order to make sure the cover art never clashes with whatever the background color is, added a gradient where the top is the average color of all colors in the cover and it fades to black so that we always have good contrast for the controls. If for whatever reason this fails, we default to the original blue, and if we cannot find the album art, we use the app icon (we can make a new empty state if we want something original). 

Also changed the "three-dot" icon to base its color on whatever tint we provide so that we can use Chameleon's high contrast extension based on the average color. 

I set up my last branch a bit funky and then branched off of it, so I've got some extra code changes here (the smart rewind feature), but I figure instead of going through trying to properly undo the storyboard shenanigans, I'd push this up with some screenshots and get your input so I can keep making any changes. Going forward I'll make sure my master is clean and any features are on their own branches!

Here's some example screenshots, one with a dark book cover and one light: 

<img width="598" alt="v2_1" src="https://user-images.githubusercontent.com/746545/32131900-2e6d5a56-bb6e-11e7-9d20-3fa7b7dce820.png">

<img width="598" alt="v2_2" src="https://user-images.githubusercontent.com/746545/32131903-338bdf9e-bb6e-11e7-9b4b-1d924fb11487.png">

And with a possible drop shadow around the cover: 

<img width="598" alt="v2_3" src="https://user-images.githubusercontent.com/746545/32132033-a298c0da-bb70-11e7-9f1f-50c0ab2d6c63.png">
