### PR TITLE
Add global speed control

### DIFF
--- a/Audiobook Player/Base.lproj/Main.storyboard
+++ b/Audiobook Player/Base.lproj/Main.storyboard
@@ -744,6 +744,37 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="bGJ-pZ-3Dv">
+                                        <rect key="frame" x="0.0" y="220" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bGJ-pZ-3Dv" id="Mbd-vw-qrk">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Global Speed Control" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fw1-LC-Kyv">
+                                                    <rect key="frame" x="16" y="2" width="163" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VQk-Go-koN">
+                                                    <rect key="frame" x="308" y="6" width="51" height="31"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Sets the same speed for all items" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqH-6j-FDR">
+                                                    <rect key="frame" x="16" y="20" width="260" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="VQk-Go-koN" firstAttribute="centerY" secondItem="Mbd-vw-qrk" secondAttribute="centerY" id="0YD-DR-JsM"/>
+                                                <constraint firstAttribute="trailing" secondItem="VQk-Go-koN" secondAttribute="trailing" constant="18" id="oaD-Hs-KMK"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -762,6 +793,7 @@
                     <size key="freeformSize" width="375" height="600"/>
                     <connections>
                         <outlet property="boostVolumeSwitch" destination="0Nl-PG-HKW" id="tiT-du-KK6"/>
+                        <outlet property="globalSpeedSwitch" destination="VQk-Go-koN" id="GM7-fx-xNg"/>
                         <outlet property="smartRewindSwitch" destination="GRM-ck-C3M" id="69t-8D-ecN"/>
                         <outlet property="storageSizeLabel" destination="uNV-j5-Reh" id="Wt3-S0-Edr"/>
                         <outlet property="themeSwitch" destination="HLN-Bn-NgG" id="IFO-XA-MDw"/>

--- a/Audiobook Player/Constants.swift
+++ b/Audiobook Player/Constants.swift
@@ -13,4 +13,5 @@ struct UserDefaultsConstants {
     // User preferences
     static let smartRewindEnabled = "userSettingsSmartRewind";
     static let boostVolumeEnabled = "userSettingsBoostVolume";
+    static let globalSpeedEnabled = "userSettingsGlobalSpeed";
 }

--- a/Audiobook Player/PlayerManager.swift
+++ b/Audiobook Player/PlayerManager.swift
@@ -113,7 +113,7 @@ class PlayerManager: NSObject {
             }
             
             //set smart speed
-            let speed = self.defaults.float(forKey: self.identifier+"_speed")
+            let speed = self.defaults.bool(forKey: UserDefaultsConstants.globalSpeedEnabled) ? self.defaults.float(forKey: "global_speed") : self.defaults.float(forKey: self.identifier+"_speed")
             PlayerManager.sharedInstance.currentSpeed = speed > 0 ? speed : 1.0
             
             //try loading chapters
@@ -148,7 +148,7 @@ class PlayerManager: NSObject {
             DispatchQueue.main.async(execute: {
                 
                 //set smart speed
-                let speed = self.defaults.float(forKey: self.identifier+"_speed")
+                let speed = self.defaults.bool(forKey: UserDefaultsConstants.globalSpeedEnabled) ? self.defaults.float(forKey: "global_speed") : self.defaults.float(forKey: self.identifier+"_speed")
                 self.currentSpeed = speed > 0 ? speed : 1.0
                 
                 //enable/disable chapters button
@@ -218,6 +218,11 @@ extension PlayerManager: AVAudioPlayerDelegate {
         
         self.currentSpeed = speed
         defaults.set(PlayerManager.sharedInstance.currentSpeed, forKey: self.identifier+"_speed")
+        //set global speed
+        if self.defaults.bool(forKey: UserDefaultsConstants.globalSpeedEnabled) == true {
+            self.defaults.set(speed, forKey: "global_speed")
+        }
+
         audioPlayer.rate = self.currentSpeed
     }
     

--- a/Audiobook Player/SettingsViewController.swift
+++ b/Audiobook Player/SettingsViewController.swift
@@ -13,6 +13,7 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var themeSwitch: UISwitch!
     @IBOutlet weak var smartRewindSwitch: UISwitch!
     @IBOutlet weak var boostVolumeSwitch: UISwitch!
+    @IBOutlet weak var globalSpeedSwitch: UISwitch!
 
     let defaults:UserDefaults = UserDefaults.standard
     
@@ -21,6 +22,7 @@ class SettingsViewController: UITableViewController {
         
         smartRewindSwitch.addTarget(self, action: #selector(self.rewindToggleDidChange), for: .valueChanged)
         boostVolumeSwitch.addTarget(self, action: #selector(self.boostVolumeToggleDidChange), for: .valueChanged)
+        globalSpeedSwitch.addTarget(self, action: #selector(self.globalSpeedToggleDidChange), for: .valueChanged)
 
         //set colors
         self.navigationController?.navigationBar.barTintColor = UIColor.flatSkyBlue()
@@ -28,6 +30,7 @@ class SettingsViewController: UITableViewController {
         //Set initial switch positions
         smartRewindSwitch.setOn(defaults.bool(forKey: UserDefaultsConstants.smartRewindEnabled), animated: false)
         boostVolumeSwitch.setOn(defaults.bool(forKey: UserDefaultsConstants.boostVolumeEnabled), animated: false)
+        globalSpeedSwitch.setOn(defaults.bool(forKey: UserDefaultsConstants.globalSpeedEnabled), animated: false)
 
 //        FileManager
     }
@@ -38,6 +41,10 @@ class SettingsViewController: UITableViewController {
 
     @objc func boostVolumeToggleDidChange(){
         defaults.set(boostVolumeSwitch.isOn, forKey:UserDefaultsConstants.boostVolumeEnabled)
+    }
+
+    @objc func globalSpeedToggleDidChange(){
+        defaults.set(globalSpeedSwitch.isOn, forKey:UserDefaultsConstants.globalSpeedEnabled)
     }
 
     @IBAction func didPressClose(_ sender: UIBarButtonItem) {
@@ -51,7 +58,7 @@ class SettingsViewController: UITableViewController {
         case 0, 1:
             return 0
         default:
-            return 2
+            return 3
         }
     }
 }


### PR DESCRIPTION
While listening to an audiobook, I do not want to set speed for every item manually. With this switch, users are able to set a global speed that will be used if the switch is on.