### PR TITLE
Handle error on book deletion

### DIFF
--- a/Audiobook Player/ListBooksViewController.swift
+++ b/Audiobook Player/ListBooksViewController.swift
@@ -266,19 +266,19 @@ extension ListBooksViewController: UITableViewDelegate {
             }))
 
             alert.addAction(UIAlertAction(title: "Yes", style: .destructive, handler: { _ in
-                let book = self.bookArray.remove(at: indexPath.row)
+                let book = self.bookArray[indexPath.row]
 
                 do {
                     try FileManager.default.removeItem(at: book.fileURL)
+                    
+                    self.bookArray.remove(at: indexPath.row)
+                    tableView.beginUpdates()
+                    tableView.deleteRows(at: [indexPath], with: .none)
+                    tableView.endUpdates()
+                    self.emptyListContainerView.isHidden = !self.bookArray.isEmpty
                 } catch {
-                    // @TODO: Handle error when failing to remove a file
+                    self.showAlert("Error", message: "There was an error deleting the book, please try again.", style: .alert)
                 }
-
-                tableView.beginUpdates()
-                tableView.deleteRows(at: [indexPath], with: .none)
-                tableView.endUpdates()
-
-                self.emptyListContainerView.isHidden = !self.bookArray.isEmpty
             }))
 
             alert.popoverPresentationController?.sourceView = self.view


### PR DESCRIPTION
If there's an error on deleting a book, an alert will be presented notifying the user of the error.

As it was, if there was an error, the book would have been deleted from the list but not from the file system, potentially showing the book again on the next app launch

Resolves #26 