### PR TITLE
Bugfix: Allow player modal to adjust statusbar style

### DIFF
--- a/BookPlayer/Base.lproj/Main.storyboard
+++ b/BookPlayer/Base.lproj/Main.storyboard
@@ -201,8 +201,6 @@
                     <toolbarItems>
                         <barButtonItem title="Foo" id="2ev-Bd-I3K"/>
                     </toolbarItems>
-                    <nil key="simulatedTopBarMetrics"/>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics" translucent="NO"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="v0H-bj-b1c">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -220,7 +218,7 @@
         <!--Player-->
         <scene sceneID="yUG-lL-AsK">
             <objects>
-                <viewController storyboardIdentifier="PlayerViewController" title="Player" modalPresentationStyle="overFullScreen" id="JEX-9P-axG" customClass="PlayerViewController" customModule="BookPlayer" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PlayerViewController" title="Player" modalPresentationStyle="overCurrentContext" id="JEX-9P-axG" customClass="PlayerViewController" customModule="BookPlayer" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="svH-Pt-448">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -75,16 +75,6 @@
 	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>
-	<key>UIStatusBarTintParameters</key>
-	<dict>
-		<key>UINavigationBar</key>
-		<dict>
-			<key>Style</key>
-			<string>UIBarStyleDefault</string>
-			<key>Translucent</key>
-			<false/>
-		</dict>
-	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -97,6 +87,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/BookPlayer/Player/PlayerViewController.swift
+++ b/BookPlayer/Player/PlayerViewController.swift
@@ -31,6 +31,7 @@ class PlayerViewController: UIViewController, UIGestureRecognizerDelegate {
     private weak var progressViewController: PlayerProgressViewController?
 
     let darknessThreshold: CGFloat = 0.2
+    var expectedStatusBarStyle: UIStatusBarStyle = .default
 
     // MARK: Lifecycle
 
@@ -95,9 +96,13 @@ class PlayerViewController: UIViewController, UIGestureRecognizerDelegate {
         self.pan.cancelsTouchesInView = true
 
         self.view.addGestureRecognizer(self.pan)
+
+        self.modalPresentationCapturesStatusBarAppearance = true
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         self.controlsViewController?.showPlayPauseButton(animated)
     }
 
@@ -131,12 +136,11 @@ class PlayerViewController: UIViewController, UIGestureRecognizerDelegate {
         self.backgroundImage.alpha = 0.2
         self.backgroundImage.image = currentBook.artwork
 
-        // UIViewControllerBasedStatusBarAppearance does not seem to work for ViewControllers that are presented with Over Full Screen
-        UIApplication.shared.statusBarStyle = colors.isDark ? UIStatusBarStyle.lightContent : UIStatusBarStyle.default
+        self.expectedStatusBarStyle = colors.isDark ? UIStatusBarStyle.lightContent : UIStatusBarStyle.default
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        UIApplication.shared.statusBarStyle = UIStatusBarStyle.default
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return self.expectedStatusBarStyle
     }
 
     // MARK: Interface actions


### PR DESCRIPTION
Using `self.modalPresentationCapturesStatusBarAppearance` was missing from the modal VC which is why setting `preferredStatusBarStyle` didn't work as expected.

Re #94