### PR TITLE
Bugfix: Actually pause playback when switching audio routes

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -166,7 +166,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Pause playback if route changes due to a disconnect
         switch reason {
         case .oldDeviceUnavailable:
-            PlayerManager.shared.play()
+            PlayerManager.shared.pause()
         default:
             break
         }


### PR DESCRIPTION
Small error, interesting result, this brings it back to the original behavior.