### PR TITLE
Fix crash when deleting books before loading one in the player

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -18,18 +18,16 @@ class PlayerManager: NSObject {
     var fileURL: URL!
     var identifier: String!
 
-    var currentBooks: [Book]!
+    lazy var currentBooks = [Book]()
     var currentBook: Book! {
         return self.currentBooks.first
     }
 
     private var timer: Timer!
 
-    // swiftlint:disable:next function_body_length
     func load(_ books: [Book], completion:@escaping (AVAudioPlayer?) -> Void) {
         if let player = self.audioPlayer,
-            let currentBooks = self.currentBooks,
-            currentBooks.count == books.count { // @TODO : fix logic
+            self.currentBooks.count == books.count { // @TODO : fix logic
                 player.stop()
                 // notify?
         }


### PR DESCRIPTION
Turns out the crash wasn't because `currentBook` was forcefully unwrapped, but because `currentBooks` was being accessed before it was initialized