### PR TITLE
Change how to handle file loading errors

### DIFF
--- a/BookPlayer/Extensions/Extensions.swift
+++ b/BookPlayer/Extensions/Extensions.swift
@@ -14,8 +14,6 @@ extension Notification.Name {
         public static let requestReview = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.requestreview")
         public static let updatePercentage = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.percentage")
         public static let updateChapter = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.chapter")
-        public static let loadingBook = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.loading")
-        public static let errorLoadingBook = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.error")
         public static let bookReady = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.ready")
         public static let bookPlayed = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.play")
         public static let bookPaused = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.pause")

--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -104,7 +104,12 @@ class BaseListViewController: UIViewController {
         MBProgressHUD.showAdded(to: self.view, animated: true)
 
         // Replace player with new one
-        PlayerManager.shared.load(books) { (_) in
+        PlayerManager.shared.load(books) { (loaded) in
+            guard loaded else {
+                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                self.showAlert("File error!", message: "This book's file couldn't be loaded. Make sure you're not using files with DRM protection (like .aax files)")
+                return
+            }
             self.showPlayerView(book: book)
 
             PlayerManager.shared.playPause()

--- a/BookPlayer/Library/RootViewController.swift
+++ b/BookPlayer/Library/RootViewController.swift
@@ -43,7 +43,7 @@ class RootViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(self.bookChange(_:)), name: Notification.Name.AudiobookPlayer.bookChange, object: nil)
 
         // Register for book loading notifications
-        NotificationCenter.default.addObserver(self, selector: #selector(self.bookLoading(_:)), name: Notification.Name.AudiobookPlayer.loadingBook, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.bookReady(_:)), name: Notification.Name.AudiobookPlayer.bookReady, object: nil)
 
         //
         NotificationCenter.default.addObserver(self, selector: #selector(self.dismissMiniPlayer), name: Notification.Name.AudiobookPlayer.playerPresented, object: nil)
@@ -103,7 +103,7 @@ class RootViewController: UIViewController {
         PlayerManager.shared.play()
     }
 
-    @objc func bookLoading(_ notification: Notification) {
+    @objc func bookReady(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
             let book = userInfo["book"] as? Book else {
                 return


### PR DESCRIPTION
- Avoids showing the player when the player couldn't load the file
- Shows an alert about the error, hinting that it might be due to DRM

This in part fixes ##110