### PR TITLE
Fix importing multiple files

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -65,7 +65,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         // This function is called when the app is opened with a audio file url,
         // like when receiving files through AirDrop
-        DataManager.processExternalFiles([url])
+        let userInfo = ["fileURL": url]
+        NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.libraryOpenURL, object: nil, userInfo: userInfo)
 
         return true
     }

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -65,27 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         // This function is called when the app is opened with a audio file url,
         // like when receiving files through AirDrop
-
-        let fmanager = FileManager.default
-        let filename = url.lastPathComponent
-        let documentsURL = fmanager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let destinationURL = documentsURL.appendingPathComponent(filename)
-
-        // move file from Inbox to Document folder
-        do {
-            try fmanager.moveItem(at: url, to: destinationURL)
-            // In case the app was already running in background
-            let userInfo = ["fileURL": destinationURL]
-            NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.openURL, object: nil, userInfo: userInfo)
-        } catch {
-            do {
-                try fmanager.removeItem(at: url)
-            } catch {
-                // @TODO: How should this case be handled?
-            }
-
-            return false
-        }
+        DataManager.processExternalFiles([url])
 
         return true
     }

--- a/BookPlayer/Extensions/Extensions.swift
+++ b/BookPlayer/Extensions/Extensions.swift
@@ -10,7 +10,8 @@ import UIKit
 
 extension Notification.Name {
     public struct AudiobookPlayer {
-        public static let openURL = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.openurl")
+        public static let libraryOpenURL = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.library.openurl")
+        public static let playlistOpenURL = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.playlist.openurl")
         public static let requestReview = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.requestreview")
         public static let updatePercentage = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.percentage")
         public static let updateChapter = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.chapter")
@@ -22,7 +23,7 @@ extension Notification.Name {
         public static let bookChange = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.change")
         public static let bookPlaying = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.playback")
         public static let skipIntervalsChange = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.settings.skip")
-        public static let bookDeleted = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.book.deleted")
+        public static let reloadData = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.reloaddata")
         public static let playerPresented = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.player.presented")
         public static let playerDismissed = Notification.Name(rawValue: "com.tortugapower.audiobookplayer.player.dismissed")
     }

--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -168,6 +168,25 @@ class BaseListViewController: UIViewController {
 
         cell.progress = progress
     }
+
+    @objc func openURL(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+            let fileURL = userInfo["fileURL"] as? URL else {
+                return
+        }
+
+        MBProgressHUD.showAdded(to: self.view, animated: true)
+
+        let destinationFolder = DataManager.getProcessedFolderURL()
+
+        DataManager.processFile(at: fileURL, destinationFolder: destinationFolder) { (bookUrl) in
+            guard let bookUrl = bookUrl else {
+                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                return
+            }
+            self.loadFile(urls: [bookUrl])
+        }
+    }
 }
 
 extension BaseListViewController: UITableViewDataSource {
@@ -294,6 +313,9 @@ extension BaseListViewController: TableViewReorderDelegate {
 
 extension BaseListViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-        DataManager.processExternalFiles(urls)
+        for url in urls {
+            let userInfo = ["fileURL": url]
+            NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.libraryOpenURL, object: nil, userInfo: userInfo)
+        }
     }
 }

--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -92,6 +92,10 @@ class BaseListViewController: UIViewController {
 
         providerList.delegate = self
 
+        if #available(iOS 11.0, *) {
+            providerList.allowsMultipleSelection = true
+        }
+
         self.present(providerList, animated: true, completion: nil)
     }
 
@@ -290,47 +294,6 @@ extension BaseListViewController: TableViewReorderDelegate {
 
 extension BaseListViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-        guard let url = urls.first else {
-            return
-        }
-
-        // @TODO: Consider importing multiple files at once
-
-        self.addFileFromUrl(url)
-    }
-
-    func addFileFromUrl(_ url: URL) {
-        // Documentation states that the file might not be imported due to being accessed from somewhere else
-
-        do {
-            try FileManager.default.attributesOfItem(atPath: url.path)
-        } catch {
-            self.showAlert("Error", message: "There was an error reading the file, please try again.")
-
-            return
-        }
-
-        let trueName = url.lastPathComponent
-        var finalPath = self.documentsPath + "/" + (trueName)
-
-        if trueName.contains(" ") {
-            finalPath = finalPath.replacingOccurrences(of: " ", with: "_")
-        }
-
-        let fileURL = URL(fileURLWithPath: finalPath.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!)
-
-        do {
-            try FileManager.default.moveItem(at: url, to: fileURL)
-        } catch {
-            self.showAlert("Error", message: "There was an error importing the file, please try again.")
-
-            return
-        }
-
-        MBProgressHUD.showAdded(to: self.view, animated: true)
-
-        DataManager.processPendingFiles { (urls) in
-            self.loadFile(urls: urls)
-        }
+        DataManager.processExternalFiles(urls)
     }
 }

--- a/BookPlayer/Library/DataManager.swift
+++ b/BookPlayer/Library/DataManager.swift
@@ -95,7 +95,8 @@ class DataManager {
      - Returns: `URL` of the file's new location. Returns `nil` if hashing fails.
      */
     class func processFile(at origin: URL, destinationFolder: URL, completion:@escaping (URL?) -> Void) {
-        guard let inputStream = InputStream(url: origin) else {
+        guard FileManager.default.fileExists(atPath: origin.path),
+            let inputStream = InputStream(url: origin) else {
             completion(nil)
             return
         }

--- a/BookPlayer/Library/DataManager.swift
+++ b/BookPlayer/Library/DataManager.swift
@@ -170,6 +170,30 @@ class DataManager {
         self.processFiles(in: documentsFolder, completion: completion)
     }
 
+    /**
+     Process 'external' files coming via AirDrop or importing files functionality
+     */
+    class func processExternalFiles(_ urls: [URL]) {
+        for url in urls {
+            let documentsURL = self.getDocumentsFolderURL()
+            let filename = url.lastPathComponent
+            let destinationURL = documentsURL.appendingPathComponent(filename)
+
+            // move file from Inbox to Document folder
+            do {
+                try FileManager.default.moveItem(at: url, to: destinationURL)
+                let userInfo = ["fileURL": destinationURL]
+                NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.openURL, object: nil, userInfo: userInfo)
+            } catch {
+                do {
+                    try FileManager.default.removeItem(at: url)
+                } catch {
+                    // @TODO: How should this case be handled?
+                }
+            }
+        }
+    }
+
     // MARK: - Models handler
 
     /**

--- a/BookPlayer/Library/DataManager.swift
+++ b/BookPlayer/Library/DataManager.swift
@@ -94,69 +94,44 @@ class DataManager {
      - Parameter destinationFolder: File final location
      - Returns: `URL` of the file's new location. Returns `nil` if hashing fails.
      */
-    class func processFile(at origin: URL, destinationFolder: URL) -> URL? {
+    class func processFile(at origin: URL, destinationFolder: URL, completion:@escaping (URL?) -> Void) {
         guard let inputStream = InputStream(url: origin) else {
-            return nil
-        }
-
-        inputStream.open()
-
-        let digest = Digest(algorithm: .md5)
-
-        while inputStream.hasBytesAvailable {
-            var inputBuffer = [UInt8](repeating: 0, count: 1024)
-            inputStream.read(&inputBuffer, maxLength: inputBuffer.count)
-            _ = digest.update(byteArray: inputBuffer)
-        }
-
-        inputStream.close()
-
-        let finalDigest = digest.final()
-
-        let hash = hexString(fromArray: finalDigest)
-        let ext = origin.pathExtension
-        let filename = hash + ".\(ext)"
-        let destinationURL = destinationFolder.appendingPathComponent(filename)
-
-        do {
-            if !FileManager.default.fileExists(atPath: destinationURL.path) {
-                try FileManager.default.moveItem(at: origin, to: destinationURL)
-            } else {
-                try FileManager.default.removeItem(at: origin)
-            }
-        } catch {
-            fatalError("Fail to move file from \(origin) to \(destinationURL)")
-        }
-
-        return destinationURL
-    }
-
-    /**
-     Process all the files in a folder and move them to the 'processed' folder (specified by the DataManager).
-     - Parameter folder: The folder which contents will be processed
-     - Parameter completion: Closure block which returns the array of new urls of the processed files
-     */
-    internal class func processFiles(in folder: URL, completion:@escaping ([URL]) -> Void) {
-        var bookUrls = [URL]()
-
-        // Get reference of all the files located inside the Documents folder
-        guard let urls = self.getFiles(from: folder) else {
-            return completion(bookUrls)
+            completion(nil)
+            return
         }
 
         DispatchQueue.global().async {
-            // Iterate and process files
-            let destinationFolder = self.getProcessedFolderURL()
+            inputStream.open()
 
-            for fileURL in urls {
-                guard let bookUrl = self.processFile(at: fileURL, destinationFolder: destinationFolder) else {
-                    continue
+            let digest = Digest(algorithm: .md5)
+
+            while inputStream.hasBytesAvailable {
+                var inputBuffer = [UInt8](repeating: 0, count: 1024)
+                inputStream.read(&inputBuffer, maxLength: inputBuffer.count)
+                _ = digest.update(byteArray: inputBuffer)
+            }
+
+            inputStream.close()
+
+            let finalDigest = digest.final()
+
+            let hash = hexString(fromArray: finalDigest)
+            let ext = origin.pathExtension
+            let filename = hash + ".\(ext)"
+            let destinationURL = destinationFolder.appendingPathComponent(filename)
+
+            do {
+                if !FileManager.default.fileExists(atPath: destinationURL.path) {
+                    try FileManager.default.moveItem(at: origin, to: destinationURL)
+                } else {
+                    try FileManager.default.removeItem(at: origin)
                 }
-                bookUrls.append(bookUrl)
+            } catch {
+                fatalError("Fail to move file from \(origin) to \(destinationURL)")
             }
 
             DispatchQueue.main.async {
-                completion(bookUrls)
+                completion(destinationURL)
             }
         }
     }
@@ -165,32 +140,17 @@ class DataManager {
      Process all the files in the documents folder and move them to the 'processed' folder (specified by the DataManager).
      - Parameter completion: Closure block which returns the array of new urls of the processed files
      */
-    class func processPendingFiles(completion:@escaping ([URL]) -> Void) {
+    class func notifyPendingFiles() {
         let documentsFolder = self.getDocumentsFolderURL()
-        self.processFiles(in: documentsFolder, completion: completion)
-    }
 
-    /**
-     Process 'external' files coming via AirDrop or importing files functionality
-     */
-    class func processExternalFiles(_ urls: [URL]) {
+        // Get reference of all the files located inside the folder
+        guard let urls = self.getFiles(from: documentsFolder) else {
+            return
+        }
+
         for url in urls {
-            let documentsURL = self.getDocumentsFolderURL()
-            let filename = url.lastPathComponent
-            let destinationURL = documentsURL.appendingPathComponent(filename)
-
-            // move file from Inbox to Document folder
-            do {
-                try FileManager.default.moveItem(at: url, to: destinationURL)
-                let userInfo = ["fileURL": destinationURL]
-                NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.openURL, object: nil, userInfo: userInfo)
-            } catch {
-                do {
-                    try FileManager.default.removeItem(at: url)
-                } catch {
-                    // @TODO: How should this case be handled?
-                }
-            }
+            let userInfo = ["fileURL": url]
+            NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.libraryOpenURL, object: nil, userInfo: userInfo)
         }
     }
 

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -21,8 +21,8 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
         self.navigationController!.interactivePopGestureRecognizer!.delegate = self
 
         // register for appDelegate openUrl notifications
-        NotificationCenter.default.addObserver(self, selector: #selector(self.openURL(_:)), name: Notification.Name.AudiobookPlayer.openURL, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.reloadData), name: Notification.Name.AudiobookPlayer.bookDeleted, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.openURL(_:)), name: Notification.Name.AudiobookPlayer.libraryOpenURL, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.reloadData), name: Notification.Name.AudiobookPlayer.reloadData, object: nil)
 
         self.loadLibrary()
 
@@ -54,30 +54,13 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
      *  Spaces in file names can cause side effects when trying to load the data
      */
     func loadLibrary() {
-        //load local files
-        let loadingWheel = MBProgressHUD.showAdded(to: self.view, animated: true)
-        loadingWheel?.labelText = "Loading Books"
-
         self.library = DataManager.getLibrary()
 
         //show/hide instructions view
         self.emptyLibraryPlaceholder.isHidden = !self.items.isEmpty
         self.tableView.reloadData()
 
-        DataManager.processPendingFiles { (urls) in
-            guard !urls.isEmpty else {
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                return
-            }
-
-            DataManager.insertBooks(from: urls, into: self.library) {
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-
-                //show/hide instructions view
-                self.emptyLibraryPlaceholder.isHidden = !self.items.isEmpty
-                self.tableView.reloadData()
-            }
-        }
+        DataManager.notifyPendingFiles()
     }
 
     override func loadFile(urls: [URL]) {
@@ -86,24 +69,6 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
             self.emptyLibraryPlaceholder.isHidden = !self.items.isEmpty
             self.tableView.reloadData()
         }
-    }
-
-    @objc func openURL(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-            let fileURL = userInfo["fileURL"] as? URL else {
-                return
-        }
-
-        MBProgressHUD.showAdded(to: self.view, animated: true)
-
-        let destinationFolder = DataManager.getProcessedFolderURL()
-
-        guard let bookUrl = DataManager.processFile(at: fileURL, destinationFolder: destinationFolder) else {
-            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            return
-        }
-
-        self.loadFile(urls: [bookUrl])
     }
 
     @objc func reloadData() {

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -95,14 +95,14 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
         }
 
         MBProgressHUD.showAdded(to: self.view, animated: true)
-        
+
         let destinationFolder = DataManager.getProcessedFolderURL()
-        
+
         guard let bookUrl = DataManager.processFile(at: fileURL, destinationFolder: destinationFolder) else {
             MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
             return
         }
-        
+
         self.loadFile(urls: [bookUrl])
     }
 

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -89,11 +89,21 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
     }
 
     @objc func openURL(_ notification: Notification) {
-        MBProgressHUD.showAdded(to: self.view, animated: true)
-
-        DataManager.processPendingFiles { (urls) in
-            self.loadFile(urls: urls)
+        guard let userInfo = notification.userInfo,
+            let fileURL = userInfo["fileURL"] as? URL else {
+                return
         }
+
+        MBProgressHUD.showAdded(to: self.view, animated: true)
+        
+        let destinationFolder = DataManager.getProcessedFolderURL()
+        
+        guard let bookUrl = DataManager.processFile(at: fileURL, destinationFolder: destinationFolder) else {
+            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+            return
+        }
+        
+        self.loadFile(urls: [bookUrl])
     }
 
     @objc func reloadData() {

--- a/BookPlayer/Models/Playlist+CoreDataClass.swift
+++ b/BookPlayer/Models/Playlist+CoreDataClass.swift
@@ -35,6 +35,10 @@ public class Playlist: LibraryItem {
             totalProgress += book.currentTime
         }
 
+        guard totalDuration > 0 else {
+            return 0.0
+        }
+
         return totalProgress / totalDuration
     }
 


### PR DESCRIPTION
- We now use `InputStream` for reading the books and get the `Digest`, this avoids memory issues when trying to load multiple books at once
- Add support for devices running iOS 11 to select multiple files to import
- Hide progress view for playlists with no files